### PR TITLE
Strip stdin & gracefully handle interrupt

### DIFF
--- a/src/saltstack_age/cli.py
+++ b/src/saltstack_age/cli.py
@@ -149,7 +149,10 @@ def get_recipients(arguments: Namespace) -> list[pyrage.x25519.Recipient]:
 
 
 def get_value(arguments: Namespace) -> str:
-    return arguments.value or sys.stdin.read().rstrip()
+    try:
+        return arguments.value or sys.stdin.read().rstrip()
+    except KeyboardInterrupt as exc:
+        raise SystemExit(-1) from exc
 
 
 def determine_encryption_type(

--- a/src/saltstack_age/cli.py
+++ b/src/saltstack_age/cli.py
@@ -149,7 +149,7 @@ def get_recipients(arguments: Namespace) -> list[pyrage.x25519.Recipient]:
 
 
 def get_value(arguments: Namespace) -> str:
-    return arguments.value or sys.stdin.read()
+    return arguments.value or sys.stdin.read().rstrip()
 
 
 def determine_encryption_type(


### PR DESCRIPTION
[fix: strip stdin](https://github.com/pmuller/saltstack-age/commit/f944f14d8b53c483c4538cf0f985308e187f43c3)

When piping tools such as openssl or pwgen into "saltstack-age enc",
the encrypted value would contain a trailing newline, causing unexpected
results in Salt states interpreting the pillar values.

[fix: gracefully handle interrupt](https://github.com/pmuller/saltstack-age/commit/81c25e3cca87a46005c9a8d916c038aab75047a0)

When deciding not to proceed with the encryption from stdin, avoid a
traceback upon Ctrl+C.